### PR TITLE
HTTPS Access

### DIFF
--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -70,7 +70,7 @@ const stack = {
                 Protocol: 'HTTP'
             }
         },
-        HTTPSListener: {
+        HttpsListener: {
             Type: 'AWS::ElasticLoadBalancingV2::Listener',
             Properties: {
                 DefaultActions: [{
@@ -82,7 +82,7 @@ const stack = {
                 }],
                 LoadBalancerArn: cf.ref('ELB'),
                 Port: 443,
-                Protocol: 'HTTP'
+                Protocol: 'HTTPS'
             }
         },
         TargetGroup: {

--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -11,6 +11,10 @@ const stack = {
             Type: 'String',
             Description: 'Email address to be used to send emails'
         },
+        CertificateARN: {
+            Type: 'String',
+            Description: 'SSL Certificate ARN'
+        },
         FrontEndDomain: {
             Type: 'String',
             Description: 'Domain at which the frontend resides'
@@ -44,26 +48,40 @@ const stack = {
                 SecurityGroupIngress: [{
                     CidrIp: '0.0.0.0/0',
                     IpProtocol: 'tcp',
-                    FromPort: 80,
-                    ToPort: 80
-                },{
-                    CidrIp: '0.0.0.0/0',
-                    IpProtocol: 'tcp',
                     FromPort: 443,
                     ToPort: 443
                 }],
                 VpcId: cf.ref('VPC')
             }
         },
-        HTTPListener: {
+        HttpListener: {
+            Type: 'AWS::ElasticLoadBalancingV2::Listener',
+            Properties: {
+                DefaultActions: [{
+                    Type: 'redirect',
+                    RedirectConfig: {
+                        Protocol: 'HTTPS',
+                        StatusCode: 'HTTP_301',
+                        Port: 443
+                    }
+                }],
+                LoadBalancerArn: cf.ref('ELB'),
+                Port: 80,
+                Protocol: 'HTTP'
+            }
+        },
+        HTTPSListener: {
             Type: 'AWS::ElasticLoadBalancingV2::Listener',
             Properties: {
                 DefaultActions: [{
                     Type: 'forward',
                     TargetGroupArn: cf.ref('TargetGroup')
                 }],
+                Certificates: [{
+                    CertificateArn: cf.ref('CertificateARN')
+                }],
                 LoadBalancerArn: cf.ref('ELB'),
-                Port: 80,
+                Port: 443,
                 Protocol: 'HTTP'
             }
         },


### PR DESCRIPTION
### Context

To protect access credentials, all public access should be done via HTTPS

#### Actions
- [x] Redirect HTTP => HTTPS
- [x] Add Listener to HTTPS
- [x] Create & Add ability to specify SSL Cert