### PR TITLE
Add support for http => https redirect

### DIFF
--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -50,6 +50,11 @@ const stack = {
                     IpProtocol: 'tcp',
                     FromPort: 443,
                     ToPort: 443
+                },{
+                    CidrIp: '0.0.0.0/0',
+                    IpProtocol: 'tcp',
+                    FromPort: 80,
+                    ToPort: 80
                 }],
                 VpcId: cf.ref('VPC')
             }


### PR DESCRIPTION
### Context

I had added redirect support via the built in ELB redirect ability but since I had not enabled a security opening, traffic could not hit the ELB to be redirected.