### PR TITLE
Action Master

### DIFF
--- a/.github/workflows/ecr_api.yml
+++ b/.github/workflows/ecr_api.yml
@@ -1,6 +1,9 @@
 name: AWS ECR API
 
 on:
+    push:
+      branches:
+        - main
     pull_request:
         types:
             - opened
@@ -15,7 +18,7 @@ jobs:
         steps:
             - uses: actions/checkout@v2
               with:
-                  ref: ${{ github.event.pull_request.head.sha }}
+                  ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
             - name: Docker Build API
               run: docker build -t api api/
@@ -32,7 +35,7 @@ jobs:
               uses: aws-actions/amazon-ecr-login@v1
 
             - name: Docker Tag API
-              run: docker tag api ${{secrets.AWS_ACCOUNT_ID}}.dkr.ecr.us-east-1.amazonaws.com/raster-uploader:${{github.event.pull_request.head.sha}}
+              run: docker tag api ${{secrets.AWS_ACCOUNT_ID}}.dkr.ecr.us-east-1.amazonaws.com/raster-uploader:${{github.event.pull_request.head.sha || github.sha}}
 
             - name: Docker Push API
-              run: docker push ${{secrets.AWS_ACCOUNT_ID}}.dkr.ecr.us-east-1.amazonaws.com/raster-uploader:${{github.event.pull_request.head.sha}}
+              run: docker push ${{secrets.AWS_ACCOUNT_ID}}.dkr.ecr.us-east-1.amazonaws.com/raster-uploader:${{github.event.pull_request.head.sha || github.sha}}

--- a/.github/workflows/ecr_task.yml
+++ b/.github/workflows/ecr_task.yml
@@ -1,6 +1,9 @@
 name: AWS ECR Tasks
 
 on:
+    push:
+      branches:
+        - main
     pull_request:
         types:
             - opened
@@ -21,7 +24,7 @@ jobs:
         steps:
             - uses: actions/checkout@v2
               with:
-                  ref: ${{ github.event.pull_request.head.sha }}
+                  ref: ${{github.event.pull_request.head.sha || github.sha}}
 
             - name: Docker Build Task
               run: docker build -t task-${{matrix.task}} tasks/${{matrix.task}}
@@ -38,7 +41,7 @@ jobs:
               uses: aws-actions/amazon-ecr-login@v1
 
             - name: Docker Tag API
-              run: docker tag task-${{matrix.task}} ${{secrets.AWS_ACCOUNT_ID}}.dkr.ecr.us-east-1.amazonaws.com/raster-uploader:task-${{matrix.task}}-${{github.event.pull_request.head.sha}}
+              run: docker tag task-${{matrix.task}} ${{secrets.AWS_ACCOUNT_ID}}.dkr.ecr.us-east-1.amazonaws.com/raster-uploader:task-${{matrix.task}}-${{github.event.pull_request.head.sha || github.sha}}
 
             - name: Docker Push API
-              run: docker push ${{secrets.AWS_ACCOUNT_ID}}.dkr.ecr.us-east-1.amazonaws.com/raster-uploader:task-${{matrix.task}}-${{github.event.pull_request.head.sha}}
+              run: docker push ${{secrets.AWS_ACCOUNT_ID}}.dkr.ecr.us-east-1.amazonaws.com/raster-uploader:task-${{matrix.task}}-${{github.event.pull_request.head.sha || github.sha}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 
 on:
+    push:
+      branches:
+        - main
     pull_request:
         types:
             - opened
@@ -16,7 +19,7 @@ jobs:
         steps:
             - uses: actions/checkout@v2
               with:
-                  ref: ${{ github.event.pull_request.head.sha }}
+                  ref: ${{github.event.pull_request.head.sha || github.sha}}
 
             - name: Docker Pull
               run: docker-compose pull

--- a/.github/workflows/test_task.yml
+++ b/.github/workflows/test_task.yml
@@ -1,6 +1,9 @@
 name: Test Tasks
 
 on:
+    push:
+      branches:
+        - main
     pull_request:
         types:
             - opened
@@ -23,7 +26,7 @@ jobs:
         steps:
             - uses: actions/checkout@v2
               with:
-                  ref: ${{ github.event.pull_request.head.sha }}
+                  ref: ${{github.event.pull_request.head.sha || github.sha}}
 
             - name: Install & Test
               run: |


### PR DESCRIPTION
### Context

Run GH Actions when a merge into master occurs so that deploys can take place from the last commit to master.

Huge thanks to @geohacker who figured this out ages ago

